### PR TITLE
allure reports

### DIFF
--- a/.github/workflows/run-tests-with-allure.yml
+++ b/.github/workflows/run-tests-with-allure.yml
@@ -1,0 +1,57 @@
+name: Run Python Tests
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: write
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Test with pytest and generate allure report
+      run: |
+        pytest tests --alluredir=allure-results
+      continue-on-error: true
+
+    - name: Get Allure history
+      uses: actions/checkout@v2
+      if: always()
+      continue-on-error: true
+      with:
+        ref: gh-pages
+        path: gh-pages
+
+    - name: Allure Report action from marketplace
+      uses: simple-elf/allure-report-action@master
+      if: always()
+      with:
+        allure_results: allure-results
+        allure_history: allure-history
+
+    - name: Deploy report to Github Pages
+      if: always()
+      uses: peaceiris/actions-gh-pages@v2
+      env:
+        PERSONAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: allure-history

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 *.pyc
 
 .idea
+
+report.xml
+/allure-results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.27.1
 pytest==7.1.2
 Faker==13.13.0
+allure-pytest==2.9.45


### PR DESCRIPTION
Add new workflow for Allure reports. In order to work it requires a branch with name "gh-pages"  and GitHub pages configured to use it. There is an example for allure reports in my repository: https://miniteckel.github.io/TestAutomationCourse-python-api-project/1/